### PR TITLE
Make `DialogMode.SelectFolder` return the actual result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ obj/
 /packages/
 riderModule.iml
 /_ReSharper.Caches/
+.vs/

--- a/src/NativeFileDialogNET/NativeFileDialog.cs
+++ b/src/NativeFileDialogNET/NativeFileDialog.cs
@@ -44,12 +44,7 @@ public unsafe class NativeFileDialog : IDisposable
                     Util.FreeStringPointer(item.Name);
                     Util.FreeStringPointer(item.Spec);
                 }
-                return result switch
-                {
-                    NfdResult.Okay => DialogResult.Okay,
-                    NfdResult.Cancel => DialogResult.Cancel,
-                    _ => DialogResult.Error,
-                };
+                return MapResult(result);
             }
             case DialogMode.SelectFolder:
             {
@@ -62,7 +57,7 @@ public unsafe class NativeFileDialog : IDisposable
                     Bindings.FreePath(selectedPath);
                 }
                 Util.FreeStringPointer(defaultPathPtr);
-                break;
+                return MapResult(result);
             }
             case DialogMode.SaveFile:
             {
@@ -87,15 +82,18 @@ public unsafe class NativeFileDialog : IDisposable
                     Util.FreeStringPointer(item.Name);
                     Util.FreeStringPointer(item.Spec);
                 }
-                return result switch
-                {
-                    NfdResult.Okay => DialogResult.Okay,
-                    NfdResult.Cancel => DialogResult.Cancel,
-                    _ => DialogResult.Error,
-                };
+                return MapResult(result);
             }
         }
         return DialogResult.Error;
+
+        static DialogResult MapResult(NfdResult result)
+            => result switch
+            {
+                NfdResult.Okay => DialogResult.Okay,
+                NfdResult.Cancel => DialogResult.Cancel,
+                _ => DialogResult.Error,
+            };
     }
 
     public NativeFileDialog SaveFile()


### PR DESCRIPTION
Fixes #2.

Additionally, took the liberty of extracting a utility method to map the return types and adding Visual Studio files to .gitignore.

P.S.: Thanks for creating this wrapper, honestly the best of its kind from what I can see.