### PR TITLE
Fix sample filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ using NativeFileDialogNET;
 
 using var selectFileDialog = new NativeFileDialog()
     .SelectFile()
-    .AddFilter("Text Files", "*.txt") // Optionally add filters
-    .AddFilter("All Files", "*.*") // Optionally add filters
+    .AddFilter("Text Files", "txt") // Optionally add filters
     .AllowMultiple(); // Optionally allow multiple selections
 
 DialogResult result = selectFileDialog.Open(out string[]? output, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
@@ -44,8 +43,7 @@ Console.WriteLine(result == DialogResult.Okay ? $"Selected folder(s): {builder2}
 
 using var saveFileDialog = new NativeFileDialog()
     .SaveFile()
-    .AddFilter("Text Files", "*.txt")  // Optionally add filters
-    .AddFilter("All Files", "*.*");  // Optionally add filters
+    .AddFilter("Text Files", "*.txt"); // Optionally add filters
 
 result = saveFileDialog.Open(out string? saveFile, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "DefaultName.txt");
 Console.WriteLine(result == DialogResult.Okay ? $"Selected file: {saveFile}" : "User canceled the dialog.");

--- a/samples/AotStaticLink/Program.cs
+++ b/samples/AotStaticLink/Program.cs
@@ -4,8 +4,7 @@
 
 using var selectFileDialog = new NativeFileDialog()
     .SelectFile()
-    .AddFilter("Text Files", "*.txt") // Optionally add filters
-    .AddFilter("All Files", "*.*");  // Optionally add filters
+    .AddFilter("Text Files", "txt"); // Optionally add filters
 
 DialogResult result = selectFileDialog.Open(out string? output, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
 Console.WriteLine(result == DialogResult.Okay ? $"Selected file: {output}" : "User canceled the dialog.");
@@ -18,8 +17,7 @@ Console.WriteLine(result == DialogResult.Okay ? $"Selected folder: {folder}" : "
 
 using var saveFileDialog = new NativeFileDialog()
     .SaveFile()
-    .AddFilter("Text Files", "*.txt")  // Optionally add filters
-    .AddFilter("All Files", "*.*");  // Optionally add filters
+    .AddFilter("Text Files", "txt"); // Optionally add filters
 
 result = saveFileDialog.Open(out string? saveFile, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "DefaultName.txt");
 Console.WriteLine(result == DialogResult.Okay ? $"Selected file: {saveFile}" : "User canceled the dialog.");

--- a/samples/BasicUsage/Program.cs
+++ b/samples/BasicUsage/Program.cs
@@ -3,8 +3,7 @@ using NativeFileDialogNET;
 
 using var selectFileDialog = new NativeFileDialog()
     .SelectFile()
-    .AddFilter("Text Files", "*.txt") // Optionally add filters
-    .AddFilter("All Files", "*.*") // Optionally add filters
+    .AddFilter("Text Files", "txt") // Optionally add filters
     .AllowMultiple(); // Optionally allow multiple selections
 
 DialogResult result = selectFileDialog.Open(out string[]? output, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments));
@@ -35,8 +34,7 @@ Console.WriteLine(result == DialogResult.Okay ? $"Selected folder(s): {builder2}
 
 using var saveFileDialog = new NativeFileDialog()
     .SaveFile()
-    .AddFilter("Text Files", "*.txt")  // Optionally add filters
-    .AddFilter("All Files", "*.*");  // Optionally add filters
+    .AddFilter("Text Files", "txt"); // Optionally add filters
 
 result = saveFileDialog.Open(out string? saveFile, Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "DefaultName.txt");
 Console.WriteLine(result == DialogResult.Okay ? $"Selected file: {saveFile}" : "User canceled the dialog.");


### PR DESCRIPTION
Currently, the sample filters look as follows:
![image](https://github.com/user-attachments/assets/feb24b66-8b55-43df-93f9-b257caba5f21)

The `*.` prefix and the wildcard filter are hardcoded and don't need to be manually added. This PR removes the two where they're explicitly added in sample code.